### PR TITLE
Make site mobile-friendly with responsive layout across all pages

### DIFF
--- a/marketmon-ui/src/app.css
+++ b/marketmon-ui/src/app.css
@@ -40,6 +40,8 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	min-height: 100vh;
+	overflow-x: hidden;
+	-webkit-text-size-adjust: 100%;
 }
 
 .font-display {

--- a/marketmon-ui/src/routes/+page.svelte
+++ b/marketmon-ui/src/routes/+page.svelte
@@ -278,6 +278,20 @@
 		.hero { padding: 3.5rem 1.5rem 2.5rem; }
 		.stat-strip { flex-direction: column; gap: 0.75rem; }
 		.stat-sep { display: none; }
+		.carousel-fade { width: 60px; }
+		.carousel-section { padding: 1.5rem 0 3rem; }
+	}
+
+	@media (max-width: 480px) {
+		.hero { padding: 2.5rem 1rem 2rem; }
+		.hero-sub { font-size: 0.92rem; }
+		.hero-actions { flex-direction: column; align-items: center; }
+		.btn-gold, .btn-ghost { width: 100%; max-width: 260px; text-align: center; }
+		.features { padding: 1rem 1rem 3rem; }
+		.feat { padding: 1.25rem; }
+		.stat-strip { padding: 0.75rem 1rem; margin-top: 2.5rem; }
+		.carousel-fade { width: 30px; }
+		.carousel-title { font-size: 1.25rem; }
 	}
 
 	/* ---- Carousel ---- */

--- a/marketmon-ui/src/routes/Card.svelte
+++ b/marketmon-ui/src/routes/Card.svelte
@@ -110,7 +110,7 @@
 
 </script>
 
-<div class="card-container" style={`transform: scale(${sizeMultiplier});`} on:click>
+<div class="card-container" style={`zoom: ${sizeMultiplier};`} on:click>
   <div class="card" style="background: {cardBg}">
 
     <!-- Nameplate -->
@@ -182,8 +182,13 @@
       2px 3px 12px rgba(0, 0, 0, 0.5),
       inset 0 1px 0 rgba(255, 255, 255, 0.45),
       inset 0 -1px 0 rgba(0, 0, 0, 0.12);
-    transform-origin: top left;
     box-sizing: border-box;
+  }
+
+  @media (max-width: 480px) {
+    .card-container {
+      width: 250px;
+    }
   }
 
   .card {

--- a/marketmon-ui/src/routes/Navbar.svelte
+++ b/marketmon-ui/src/routes/Navbar.svelte
@@ -118,11 +118,15 @@
 	.mobile-toggle {
 		display: none;
 		flex-direction: column;
+		justify-content: center;
+		align-items: center;
 		gap: 5px;
 		background: none;
 		border: none;
 		cursor: pointer;
-		padding: 4px;
+		padding: 10px;
+		min-width: 44px;
+		min-height: 44px;
 	}
 
 	.bar {
@@ -147,15 +151,18 @@
 	}
 
 	.mobile-link {
-		padding: 0.7rem 1rem;
+		padding: 0.75rem 1rem;
 		text-decoration: none;
 		color: var(--text-secondary);
 		font-weight: 600;
-		font-size: 0.85rem;
+		font-size: 0.9rem;
 		letter-spacing: 0.03em;
 		text-transform: uppercase;
 		border-radius: 0.375rem;
 		transition: all 0.2s ease;
+		min-height: 44px;
+		display: flex;
+		align-items: center;
 	}
 
 	.mobile-link:hover,
@@ -168,5 +175,6 @@
 		.nav-links { display: none; }
 		.mobile-toggle { display: flex; }
 		.mobile-nav { display: flex; }
+		.brand { font-size: 1.2rem; }
 	}
 </style>

--- a/marketmon-ui/src/routes/about/+page.svelte
+++ b/marketmon-ui/src/routes/about/+page.svelte
@@ -455,11 +455,23 @@
 		text-align: right;
 	}
 
+	@media (max-width: 768px) {
+		.guide-page { padding: 2rem 1.25rem 4rem; }
+		.guide-hero { margin-bottom: 2rem; }
+		.weakness-cycle { padding: 1rem; }
+	}
+
 	@media (max-width: 500px) {
 		.data-grid { grid-template-columns: 1fr; }
 		.step { flex-direction: column; gap: 0.75rem; }
+		.step { padding: 1.25rem; }
 		.wk-reason { display: none; }
 		.wk-row { gap: 0.3rem; }
 		.wk-type { font-size: 0.6rem; padding: 0.25rem 0.4rem; }
+		.guide-title { font-size: 1.75rem; }
+		.section-title { font-size: 1.25rem; }
+		.guide-page { padding: 1.5rem 1rem 3rem; }
+		.weakness-cycle { padding: 0.75rem; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+		.wk-item { font-size: 0.65rem; padding: 0.4rem 0.5rem; gap: 0.35rem; }
 	}
 </style>

--- a/marketmon-ui/src/routes/cards/+page.svelte
+++ b/marketmon-ui/src/routes/cards/+page.svelte
@@ -250,4 +250,30 @@
 		font-size: 0.9rem;
 		color: var(--text-muted);
 	}
+
+	@media (max-width: 768px) {
+		.index-page { padding: 1.5rem 1rem 3rem; }
+		.sector-row {
+			flex-wrap: nowrap;
+			overflow-x: auto;
+			justify-content: flex-start;
+			padding-bottom: 0.5rem;
+			-webkit-overflow-scrolling: touch;
+		}
+		.chip { flex-shrink: 0; }
+	}
+
+	@media (max-width: 600px) {
+		.card-grid {
+			grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+			gap: 1rem;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.page-title { font-size: 1.75rem; }
+		.card-grid {
+			grid-template-columns: 1fr;
+		}
+	}
 </style>

--- a/marketmon-ui/src/routes/play/+page.svelte
+++ b/marketmon-ui/src/routes/play/+page.svelte
@@ -670,4 +670,32 @@
 		border-color: var(--border-hover);
 		color: var(--text-primary);
 	}
+
+	/* ---- Mobile ---- */
+	@media (max-width: 768px) {
+		.battlefield { padding: 0.75rem 1rem; }
+		.field-empty { padding: 1.25rem 1.5rem; font-size: 0.8rem; }
+		.bar-track { max-width: none; }
+		.hud-label { min-width: auto; }
+		.go-card { padding: 2rem 1.5rem; }
+		.go-title { font-size: 2rem; }
+		.go-btns { flex-direction: column; align-items: center; }
+		.go-btn { width: 100%; max-width: 220px; text-align: center; }
+		.toast { max-width: 90vw; text-align: center; font-size: 0.7rem; }
+	}
+
+	@media (max-width: 480px) {
+		.arena-header { padding: 0.5rem 1rem; }
+		.battlefield { padding: 0.5rem 0.5rem; gap: 0.35rem; }
+		.zone-hud { padding: 0.4rem 0.6rem; gap: 0.5rem; }
+		.hud-label { font-size: 0.6rem; letter-spacing: 0.1em; }
+		.field-row { gap: 0.5rem; }
+		.action-bar { bottom: 50px; padding: 0.4rem 0.75rem; gap: 0.5rem; }
+		.act { padding: 0.35rem 0.7rem; font-size: 0.7rem; }
+		.hand-btn { bottom: 10px; right: 1rem; padding: 0.4rem 0.75rem; font-size: 0.65rem; }
+		.hand-scroll { padding: 0.5rem 0.75rem; gap: 0.5rem; }
+		.go-card { padding: 1.75rem 1.25rem; margin: 0 1rem; }
+		.go-title { font-size: 1.75rem; }
+		.go-sub { font-size: 0.85rem; margin-bottom: 1.5rem; }
+	}
 </style>


### PR DESCRIPTION
- Card component: replace transform:scale with CSS zoom for correct layout
  sizing, add 250px base width on small screens
- Index page: stack hero buttons on mobile, shrink carousel fade edges,
  tighten spacing for small viewports
- Cards page: horizontal-scroll sector filter chips, responsive grid
  breakpoints, single-column layout on small screens
- Arena page: responsive battlefield, action bar, game-over modal,
  hand drawer, and toast for mobile viewports
- Guide page: tighter padding, scrollable weakness chart, smaller
  headings on mobile
- Navbar: 44px minimum touch targets for hamburger and mobile links
- Global: prevent horizontal overflow, disable text size adjustment

https://claude.ai/code/session_0141UtYAAQtjpjHTsD4cF5u3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweaks across multiple pages; low risk but could cause minor layout regressions on specific devices/browsers (notably `zoom` usage).
> 
> **Overview**
> Improves mobile usability across the app with new responsive breakpoints and spacing adjustments on the home page, cards index, play/arena view, and guide.
> 
> Updates the `Card` component scaling to use CSS `zoom` (instead of `transform: scale`) and adds a smaller base width on very small screens to prevent overflow/misalignment.
> 
> Enhances mobile navigation and global layout by enforcing 44px touch targets in the navbar, preventing horizontal scrolling (`overflow-x: hidden`), and disabling iOS text auto-resizing (`-webkit-text-size-adjust`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5da61b5421bce68710b3893f14ffde42675c1b29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->